### PR TITLE
Integration of MMP Mar-databases in Kaiju (https://mmp.sfb.uit.no)

### DIFF
--- a/util/convert_mar_to_kaiju.py
+++ b/util/convert_mar_to_kaiju.py
@@ -2,15 +2,12 @@
 
 # This script maps downloaded sequence data from mmp_id to taxonomic lineage using MMP metadata. 
 # The script assumes mmp_id in column 107 and taxonomic lineage in 38. 
+# Espen M. Robertsen, 2017. espen.m.robertsen@uit.no
 
 from collections import defaultdict
 import os, sys, HTSeq
 
 mapdict = defaultdict(str)
-
-# Do sys.argv check etc. Needs these files/dirs: MarRef.tsv, MarDB.tsv, nodes.dmp, genomes/.
-#if not len(sys.argv) == 5:
-#	exit("Missing arguments. Needs 'MarRef.tsv', 'MarDB.tsv', 'nodes.dmp', 'genomes/'. len(sys.argv): "+str(len(sys.argv)))
 
 # Map downloaded metadata to the defaultdict 'mapdict'
 with open ('MarRef.tsv') as marref:
@@ -38,7 +35,7 @@ with open ('nodes.dmp') as nodes:
 		data = line.split("|")
 		taxids.add(data[0].strip())
 
-# Map mmp_id from downloaded sequences to lineages and write to stdout.
+# Map mmp_id from downloaded sequences to lineages and write to stdout in Kaiju preferred format.
 processed_mmp = set()
 warnings = defaultdict(int)
 for root, dirs, files in os.walk('genomes/'):
@@ -72,4 +69,5 @@ for root, dirs, files in os.walk('genomes/'):
 				print ">"+header+"\n", seq.seq
 			processed_mmp.add(mmp_id)
 
+# Output simple statistic to stderr
 sys.stderr.write("Warnings / Sequences removed:\nDuplicates: "+str(warnings['duplicate'])+"\nAccessions with no taxonomic lineage: "+str(warnings['nolineage'])+"\nAccessions with no taxid in nodes.dmp: "+str(warnings['notax'])+"\nSequences with asterix: "+str(warnings['asterix'])+"\n") 

--- a/util/convert_mar_to_kaiju.py
+++ b/util/convert_mar_to_kaiju.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python
+
+# This script maps downloaded sequence data from mmp_id to taxonomic lineage using MMP metadata. 
+# The script assumes mmp_id in column 107 and taxonomic lineage in 38. 
+
+from collections import defaultdict
+import os, sys, HTSeq
+
+mapdict = defaultdict(str)
+
+# Map downloaded metadata to the defaultdict 'mapdict'
+with open ('MarRef.tsv') as marref:
+	for line in marref:
+		if line.startswith("base_ID"):
+			continue
+		records = line.strip().split("\t")
+		lineage = records[37].split('|')
+		lineage = lineage[-1]
+		mapdict[records[106]] = lineage
+
+with open ('MarDB.tsv') as mardb:
+	for line in mardb:
+		if line.startswith("base_ID"):
+			continue
+		records = line.strip().split("\t")
+		lineage = records[37].split('|')
+		lineage = lineage[-1]
+		mapdict[records[106]] = lineage
+
+# Verify taxids against nodes.dmp
+taxids = set()
+with open ('nodes.dmp') as nodes:
+	for line in nodes:
+		data = line.split("|")
+		taxids.add(data[0].strip())
+
+# Map mmp_id from downloaded sequences to lineages and write to stdout.
+processed_mmp = set()
+warnings = defaultdict(int)
+for root, dirs, files in os.walk("./genomes"):
+	for filename in files:
+		if filename.endswith(".faa"):
+			counter = 1
+			for seq in HTSeq.FastaReader(os.path.join(root,filename)):
+				mmp_id = seq.name.split("_")
+				mmp_id = mmp_id[-1]
+
+				# If this mmp accession is a duplicate (already processed), skip it.
+				if mmp_id in processed_mmp:
+					warnings['duplicate']+=1
+					break
+				# If this mmp accession has no taxonomic linage for some reason, skip it.
+				if not mapdict[mmp_id]:
+					warnings['nolineage']+=1
+					break
+				# If taxonomic id is not in nodes.dmp, skip.
+				if not mapdict[mmp_id] in taxids:
+					warnings['notax']+=1
+					break
+				# If sequence contains dubious characters, skip.
+				if '*' in seq.seq:
+					warnings['asterix']+=1
+					continue 
+
+				lineage = mapdict[mmp_id]
+				header = str(counter)+"_"+mmp_id+"_"+str(lineage)
+				counter += 1
+				print ">"+header+"\n", seq.seq
+			processed_mmp.add(mmp_id)
+
+sys.stderr.write("Warnings / Sequences removed:\nDuplicates: "+str(warnings['duplicate'])+"\nAccessions with no taxonomic lineage: "+str(warnings['nolineage'])+"\nAccessions with no taxid in nodes.dmp: "+str(warnings['notax'])+"\nSequences with asterix: "+str(warnings['asterix'])+"\n") 

--- a/util/convert_mar_to_kaiju.py
+++ b/util/convert_mar_to_kaiju.py
@@ -8,6 +8,10 @@ import os, sys, HTSeq
 
 mapdict = defaultdict(str)
 
+# Do sys.argv check etc. Needs these files/dirs: MarRef.tsv, MarDB.tsv, nodes.dmp, genomes/.
+#if not len(sys.argv) == 5:
+#	exit("Missing arguments. Needs 'MarRef.tsv', 'MarDB.tsv', 'nodes.dmp', 'genomes/'. len(sys.argv): "+str(len(sys.argv)))
+
 # Map downloaded metadata to the defaultdict 'mapdict'
 with open ('MarRef.tsv') as marref:
 	for line in marref:
@@ -37,7 +41,7 @@ with open ('nodes.dmp') as nodes:
 # Map mmp_id from downloaded sequences to lineages and write to stdout.
 processed_mmp = set()
 warnings = defaultdict(int)
-for root, dirs, files in os.walk("./genomes"):
+for root, dirs, files in os.walk('genomes/'):
 	for filename in files:
 		if filename.endswith(".faa"):
 			counter = 1

--- a/util/makeDB.sh
+++ b/util/makeDB.sh
@@ -38,7 +38,7 @@ echo
 echo  "$s" -e  NCBI BLAST non-redundant protein database \"nr\":
 echo  "$tab"   like -n, but additionally including fungi and microbial eukaryotes
 echo
-echo  "$s" -m  Marine Metagenomics Portal \(MMP\) marine reference databases
+echo  "$s" -m  Marine Metagenomics Portal \(MMP\) marine reference databases, MarRef and MarDB
 echo  "$tab"   \(https://mmp.sfb.uit.no\)
 echo
 echo
@@ -155,8 +155,8 @@ then
 		echo Downloading list of marine genomes from the Marine Metagenomics Portal \(MMP\)
 		wget -nv -O download_list.txt https://s1.sfb.uit.no/public/mar/Resources/kaiju/download_list.txt
 		echo Downloading necessary metadata from MMP
-		wget -nv -O MarRef.tsv https://s1.sfb.uit.no/public/mar/MarRef/Metadatabase/MarRef.v1.0/Current.tsv
-		wget -nv -O MarDB.tsv https://s1.sfb.uit.no/public/mar/MarDB/Metadatabase/MarDB.v1.0/Current.tsv
+		wget -nv -O MarRef.tsv https://s1.sfb.uit.no/public/mar/MarRef/Metadatabase/Current.tsv
+		wget -nv -O MarDB.tsv https://s1.sfb.uit.no/public/mar/MarDB/Metadatabase/Current.tsv
 		echo Creating directory genomes/
 		mkdir -p genomes
 		echo Downloading Mar reference genomes from the MMP. This may take a while...

--- a/util/makeDB.sh
+++ b/util/makeDB.sh
@@ -150,30 +150,23 @@ tar xf taxdump.tar.gz nodes.dmp names.dmp merged.dmp
 if [ $db_mar -eq 1 ]
 then
 	python -c "import HTSeq" 2> /dev/null || (echo Missing HTSeq library for python2. Please install; exit 1;)
-
 	if [ $DL -eq 1 ]
 	then
 		echo Downloading list of marine genomes from the Marine Metagenomics Portal \(MMP\)
 		wget -nv -O download_list.txt https://s1.sfb.uit.no/public/mar/Resources/kaiju/download_list.txt
-
 		echo Downloading necessary metadata from MMP
 		wget -nv -O MarRef.tsv https://s1.sfb.uit.no/public/mar/MarRef/Metadatabase/MarRef.v1.0/Current.tsv
 		wget -nv -O MarDB.tsv https://s1.sfb.uit.no/public/mar/MarDB/Metadatabase/MarDB.v1.0/Current.tsv
-	
 		echo Creating directory genomes/
 		mkdir -p genomes
-
 		echo Downloading Mar reference genomes from the MMP. This may take a while...
-		cat download_list.txt | xargs -P $parallelDL -n 1 wget -P genomes -nv -nc
+		cat download_list.txt | xargs -P $parallelDL wget -P genomes -nv -nc
 	fi
-
 	echo Converting MMP data to kaiju format
 	convert_mar_to_kaiju.py > kaiju_db_tmp.faa
-
 	echo On the fly substitution with merged.dmp
 	cat kaiju_db_tmp.faa | perl -lsne 'BEGIN{open(F,$m);while(<F>){@F=split(/[\|\s]+/);$h{$F[0]}=$F[1]}}if(/(>.+)_(\d+)/){print $1,"_",defined($h{$2})?$h{$2}:$2;}else{print}' -- -m=merged.dmp > kaiju_db.faa
 	rm kaiju_db_tmp.faa
-	
 	echo Building Kaiju reference
 	mkbwt -n $threadsBWT -e $exponentSA -a ABCDEFGHIJKLMNOPQRSTUVWXYZ -o kaiju_db kaiju_db.faa
 	mkfmi kaiju_db


### PR DESCRIPTION
I not sure if this is of interest for the developers, but i have integrated the Marine Metagenomics Portal (MMP) Mar databases with Kaiju by modifying the makeDB script ++. 
The Mar databases (MarRef and MarDB) are marine manually curated reference databases for marine prokaryotic organisms. See https://mmp.sfb.uit.no for more information. The Mar databases will be extensively described in the Nucleic Acids Research databases issue 2018.

MMP now hosts static files for downloading and building these databases automatically, which are updated with each successive iteration of the Mar databases (https://s1.sfb.uit.no/)

Additional dependencies include Python2 and the HTSeq library for python (https://htseq.readthedocs.io)
