### PR TITLE
Allows different defaut python path

### DIFF
--- a/util/convert_mar_to_kaiju.py
+++ b/util/convert_mar_to_kaiju.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This script maps downloaded sequence data from mmp_id to taxonomic lineage using MMP metadata. 
 # The script assumes mmp_id in column 107 and taxonomic lineage in 38. 


### PR DESCRIPTION
A small modification to allows convert_mar_to_kaiju.py to work on systems where python is not in /usr/bin

Regards

Philippe